### PR TITLE
DS-536 - [B2B][Mapper Formulas] By default the first formula should be shown on the right instead of "Please Select a Formula".

### DIFF
--- a/src/app/admin/metadata/mapper-formulas/mapper-formulas.component.html
+++ b/src/app/admin/metadata/mapper-formulas/mapper-formulas.component.html
@@ -19,7 +19,6 @@
     </div>
     <div class="formula-config flex-fill border rounded p-3">
         <ng-container *ngIf="!selectedFormula">
-            <p *ngIf="formulaList.length>0" class="text-muted">Please Select a Formula</p>
             <p *ngIf="formulaList.length==0" class="text-muted">Please Create a Formula</p>
         </ng-container>
         <ng-container *ngIf="selectedFormula">

--- a/src/app/admin/metadata/mapper-formulas/mapper-formulas.component.ts
+++ b/src/app/admin/metadata/mapper-formulas/mapper-formulas.component.ts
@@ -38,6 +38,7 @@ export class MapperFormulasComponent implements OnInit {
       }))
       .subscribe(res => {
         this.formulaList = res;
+        this.selectedFormula = this.formulaList[0];
       }, err => {
         this.commonService.errorToast(err);
       });


### PR DESCRIPTION
This commit makes a change so that the first formula is displayed on the right when the screen is loaded. Previously, the default behavior was to display the text `"Please Select a Formula"` on the right.
The purpose of this change is to enhance the user experience. By showing the first formula by default, we eliminate the need for users to manually select a formula.

