### PR TITLE
DS-675 - [App panel] After creating a new variable, the save button doesn't close the dialog box

### DIFF
--- a/src/app/home/app-manage/app-secrets/app-secrets.component.ts
+++ b/src/app/home/app-manage/app-secrets/app-secrets.component.ts
@@ -57,6 +57,7 @@ export class AppSecretsComponent implements OnInit, OnDestroy {
   saveVariable() {
     if (this.selectedIndex > -1) {
       this.varList.splice(this.selectedIndex, 1, this.formData);
+      this.selectedIndex = -1;
     } else {
       this.varList.push(this.formData);
     }
@@ -65,6 +66,7 @@ export class AppSecretsComponent implements OnInit, OnDestroy {
         item.value = atob(item.value);
       });
       this.varList = res;
+      this.showNewVarWindow = false;
     }, err => {
       this.commonService.errorToast(err, 'Unable to Save Variable');
     });


### PR DESCRIPTION
This commit implements functionality to automatically close the dialog box after saving newly created or edited variables in the "App Variables" tab, to enhance the user experience.