### PR TITLE
DS-701 - [B2B][Constants] When the name of the constant is long, it overlaps with the type

### DIFF
--- a/src/app/home/b2b-flows-manage/flow-contants/flow-contants.component.html
+++ b/src/app/home/b2b-flows-manage/flow-contants/flow-contants.component.html
@@ -17,7 +17,9 @@
         <div class="grid-body">
             <div class="grid-row d-flex align-items-center border-bottom" [class.border-bottom]="!last"
                 *ngFor="let item of constantList;let index=index;let last=last;">
-                <div class="grid-cell border-right name">{{item.key}}</div>
+                <div class="grid-cell border-right name">
+                    <div class="key-content">{{item.key}}</div>
+                </div>
                 <div class="grid-cell border-right">{{item.dataType}}</div>
                 <div *ngIf="item.dataType=='String'" class="grid-cell border-right value text-truncate">"{{item.value}}"</div>
                 <div *ngIf="item.dataType!='String'" class="grid-cell border-right value text-truncate">{{item.value}}</div>

--- a/src/app/home/b2b-flows-manage/flow-contants/flow-contants.component.scss
+++ b/src/app/home/b2b-flows-manage/flow-contants/flow-contants.component.scss
@@ -42,4 +42,28 @@
         max-height: 300px;
     }
 
+    .grid-cell.name {
+        position: relative;
+    }
+
+    .key-content {
+        max-height: 32px;
+        overflow-x: auto; 
+        overflow-y: hidden; 
+        white-space: nowrap;
+        cursor: pointer;
+    }
+
+    .key-content::-webkit-scrollbar {
+        width: 5px;
+        height: 5px; 
+    }
+
+    .key-content::-webkit-scrollbar-thumb {
+        background-color: #888;
+    }
+
+    .key-content::-webkit-scrollbar-thumb:hover {
+        background-color: #555;
+    }
 }


### PR DESCRIPTION
Addressed the key overlapping issue in the grid display by refining CSS styles and adding horizontal scrollbars.

This is how it looks now:

![Screenshot from 2023-09-27 14-52-48](https://github.com/datanimbus/dnio-ui-author/assets/58633735/310249e6-530d-49e1-a87a-e8f64527b1da)
