### PR TITLE
Add environment variable configuration tab

### DIFF
--- a/src/app/admin/admin.component.html
+++ b/src/app/admin/admin.component.html
@@ -85,6 +85,9 @@
     <span class="d-flex align-items-center px-4 fw-400 item hover" *ngIf="isSuperAdmin">
       <span routerLinkActive="active" routerLink="users" class="text">Users</span>
     </span>
+    <span class="d-flex align-items-center px-4 fw-400 item hover" *ngIf="isSuperAdmin">
+      <span routerLinkActive="active" routerLink="env-variables" class="text">Environment Variables</span>
+    </span>
     <!-- <span class="d-flex align-items-center px-4 fw-400 item hover" *ngIf="isSuperAdmin">
       <span routerLinkActive="active" routerLink="metadata/mapper" class="text">Mapper Formulas</span>
     </span> -->

--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -46,7 +46,7 @@ import { MapperFormulasComponent } from './metadata/mapper-formulas/mapper-formu
 import { CodeEditorModule } from '../utils/code-editor/code-editor.module';
 import { CustomNodeComponent } from './metadata/custom-node/custom-node.component';
 import { NpmLibrariesComponent } from './metadata/npm-libraries/npm-libraries.component';
-
+import { EnvVariableConfigComponent } from './env-variable-config/env-variable-config.component';
 @NgModule({
   imports: [
     CommonModule,
@@ -101,7 +101,8 @@ import { NpmLibrariesComponent } from './metadata/npm-libraries/npm-libraries.co
     MetadataComponent,
     MapperFormulasComponent,
     CustomNodeComponent,
-    NpmLibrariesComponent
+    NpmLibrariesComponent,
+    EnvVariableConfigComponent
   ],
 })
 export class AdminModule { }

--- a/src/app/admin/admin.routing.ts
+++ b/src/app/admin/admin.routing.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { AdminComponent } from 'src/app/admin/admin.component';
 import { AppListComponent } from 'src/app/admin/app-list/app-list.component';
 import { UserListComponent } from 'src/app/admin/user-list/user-list.component';
+import { EnvVariableConfigComponent } from 'src/app/admin/env-variable-config/env-variable-config.component';
 import { AppManageComponent } from 'src/app/admin/app-manage/app-manage.component';
 import { AgentsComponent } from './agents/agents.component';
 import { MetadataComponent } from './metadata/metadata.component';
@@ -19,6 +20,7 @@ const routes: Routes = [
       { path: 'apps', component: AppListComponent },
       { path: 'apps/:id', component: AppManageComponent },
       { path: 'users', component: UserListComponent },
+      { path: 'env-variables', component: EnvVariableConfigComponent },
       { path: 'agents', component: AgentsComponent },
       { path: 'integration', component: AgentsComponent },
       {

--- a/src/app/admin/env-variable-config/env-variable-config.component.html
+++ b/src/app/admin/env-variable-config/env-variable-config.component.html
@@ -1,0 +1,38 @@
+<div class="d-flex align-items-start flex-column p-3">
+    <!-- Informational Text -->
+    <div class="text-muted font-14 mb-2 p-2 ml-2 pl-1">
+      <span>Please hover over the info icon to see which components need to be restarted.</span>
+    </div>
+  
+    <div class="content w-100 rounded">
+      <div class="card">
+        <div class="card-body bg-light rounded">
+          <!-- Environment Variable List -->
+          <ng-container *ngFor="let variable of envVariableList">
+            <div class="d-flex align-items-center mb-3">
+              <code class="form-label m-0 me-3 font-13 fw-500" [attr.for]="variable.label">{{ variable._id }}</code>
+  
+              <!-- Variable Input Fields -->
+              <input *ngIf="variable.type === 'string'" class="form-value form-control form-control-sm me-3"
+                [id]="variable._id" type="text" [(ngModel)]="variable.value">
+              <input *ngIf="variable.type === 'number'" class="form-value form-control form-control-sm me-3"
+                [id]="variable._id" type="number" [(ngModel)]="variable.value">
+              <input *ngIf="variable.type === 'boolean'" class="form-value form-control form-control-sm me-3" 
+                [id]="variable._id" type="text" [(ngModel)]="variable.value">
+  
+              <!-- Info Icon -->
+              <span class="dsi dsi-info-circle info-icon" data-toggle="tooltip" data-placement="top" 
+                ngbTooltip="{{ variable.usedIn }}"></span>
+  
+              <!-- Variable Description -->
+              <span class="form-info text-secondary flex-fill font-12 pl-3">
+                <label class="form-key me-2 font-13">{{ variable.description }}</label>
+              </span>
+            </div>
+          </ng-container>
+  
+          <button type="button" class="btn btn-primary" (click)="saveConfig()">Save Config</button>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/src/app/admin/env-variable-config/env-variable-config.component.scss
+++ b/src/app/admin/env-variable-config/env-variable-config.component.scss
@@ -1,0 +1,37 @@
+/* Global Styles */
+* {
+    font-family: 'Inter', sans-serif;
+}
+
+/* Container Styles */
+.content {
+    height: calc(100vh - 225px);
+    overflow-y: auto;
+}
+
+/* Form Element Styles */
+.form-label, .form-value {
+    min-width: 300px;
+    max-width: 300px;
+}
+
+/* Form Info Styles */
+.form-info {
+    word-break: break-all;
+}
+
+/* Info Icon Styles */
+.info-icon-container, .info-icon {
+    display: inline-block;
+    cursor: pointer;
+}
+
+.info-icon-container {
+    position: relative;
+}
+
+.info-icon {
+    color: #007bff; 
+    font-size: 18px;
+    margin-left: 5px;
+}

--- a/src/app/admin/env-variable-config/env-variable-config.component.spec.ts
+++ b/src/app/admin/env-variable-config/env-variable-config.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EnvVariableConfigComponent } from './env-variable-config.component';
+
+describe('EnvVariableConfigComponent', () => {
+  let component: EnvVariableConfigComponent;
+  let fixture: ComponentFixture<EnvVariableConfigComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ EnvVariableConfigComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(EnvVariableConfigComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/admin/env-variable-config/env-variable-config.component.ts
+++ b/src/app/admin/env-variable-config/env-variable-config.component.ts
@@ -1,0 +1,69 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonService } from 'src/app/utils/services/common.service';
+import { ToastrService } from 'ngx-toastr';
+import { Subscription } from 'rxjs';
+
+interface EnvironmentVariable {
+  value: any;
+  type: string;
+  _id: string;
+  usedIn: string;
+  description: string;
+}
+
+@Component({
+  selector: 'odp-env-variable-config',
+  templateUrl: './env-variable-config.component.html',
+  styleUrls: ['./env-variable-config.component.scss']
+})
+export class EnvVariableConfigComponent implements OnInit, OnDestroy {
+  envVariableList: EnvironmentVariable[] = [];
+  private subscriptions: Subscription[] = [];
+
+  constructor(
+    private commonService: CommonService,
+    private toastrService: ToastrService
+  ) {}
+
+  ngOnInit(): void {
+    this.fetchAllEnvVariables();
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach(subscription => subscription.unsubscribe());
+  }
+
+  fetchAllEnvVariables(): void {
+    const selectFields = 'value,type,_id,usedIn,description';
+    const requestParams = { noApp: true, count: 100, select: selectFields };
+
+    const subscription = this.commonService.get('user', '/admin/environmentVariable', requestParams)
+      .subscribe(
+        (res: EnvironmentVariable[]) => {
+          this.envVariableList = res.sort((a, b) => a._id.toLowerCase().localeCompare(b._id.toLowerCase()));
+        },
+        (error) => {
+          this.handleError(error);
+        }
+      );
+
+    this.subscriptions.push(subscription);
+  }
+
+  saveConfig(): void {
+    this.commonService.put('user', '/admin/environmentVariable', this.envVariableList)
+      .subscribe(
+        () => {
+          this.fetchAllEnvVariables();
+          this.toastrService.success('Environment Variable Configuration Updated');
+        },
+        (error) => {
+          this.handleError(error);
+        }
+      );
+  }
+
+  private handleError(error: any): void {
+    this.commonService.errorToast(error);
+  }
+}


### PR DESCRIPTION
This commit introduces a tab in the admin panel, allowing us to set runtime environment variables. These variables will be stored in database records, and the application can retrieve them as needed. This change addresses the issue of exposing environment variables in the kubernetes config map.

Current UI

![image](https://github.com/datanimbus/dnio-ui-author/assets/58633735/bef66e8d-7da7-4f18-9f57-4e96757ea9b6)
